### PR TITLE
evolvle typo changed to evolve

### DIFF
--- a/posts/leveling.mdx
+++ b/posts/leveling.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Leveling'
-description: 'Learn the basics of leveling, when you can evolvle, and more!'
+description: 'Learn the basics of leveling, when you can evolve, and more!'
 keywords: ["learn", "level", "evolve", "evolutions", "stages", "vivids", ""]
 ---
 


### PR DESCRIPTION
The description tag for levelling misspelled evolve as evolvle, the typo has been changed to evolve.